### PR TITLE
handle case when address is missing a country

### DIFF
--- a/src/OroCRM/Bundle/ContactBundle/Controller/Api/Rest/ContactAddressController.php
+++ b/src/OroCRM/Bundle/ContactBundle/Controller/Api/Rest/ContactAddressController.php
@@ -212,10 +212,12 @@ class ContactAddressController extends RestController implements ClassResourceIn
             $addressTypesData[] = parent::getPreparedItem($addressType);
         }
 
+        $country = $entity->getCountry();
+
         $result                = parent::getPreparedItem($entity);
         $result['types']       = $addressTypesData;
-        $result['countryIso2'] = $entity->getCountry()->getIso2Code();
-        $result['countryIso3'] = $entity->getCountry()->getIso3Code();
+        $result['countryIso2'] = $country ? $country->getIso2Code() : '';
+        $result['countryIso3'] = $country ? $country->getIso3Code() : '';
         $result['regionCode']  = $entity->getRegionCode();
 
         unset($result['owner']);


### PR DESCRIPTION
in general the code should be defensive about object dereferencing like this. even if validation is in place for this (apparently there is insufficient validation of address data during contact import), such validation rules might change later or might need to be relaxed for specific use cases.
