### PR TITLE
[CallBundle] CallController:create - get default contact if none provided

### DIFF
--- a/src/OroCRM/Bundle/AccountBundle/Entity/Account.php
+++ b/src/OroCRM/Bundle/AccountBundle/Entity/Account.php
@@ -467,6 +467,14 @@ class Account extends ExtendAccount implements Taggable, EmailHolderInterface
     }
 
     /**
+     * @return int|null
+     */
+    public function getDefaultContactId()
+    {
+        return is_object($this->defaultContact) ? $this->defaultContact->getId() : null;
+    }
+
+    /**
      * Get the primary email address of the default contact
      *
      * @return string

--- a/src/OroCRM/Bundle/CallBundle/Controller/CallController.php
+++ b/src/OroCRM/Bundle/CallBundle/Controller/CallController.php
@@ -33,6 +33,13 @@ class CallController extends Controller
         $contactId = $this->getRequest()->get('contactId');
         $accountId = $this->getRequest()->get('accountId');
 
+        $shouldGetContactIdFromAccount = !is_null($accountId) && is_null($contactId);
+        if ($shouldGetContactIdFromAccount) {
+            $account = $this->getDoctrine()->getRepository('OroCRMAccountBundle:Account')->find($accountId);
+
+            $contactId = $account->getDefaultContactId();
+        }
+
         $entity = $this->initEntity($contactId, $accountId);
         return $this->update($entity, $redirect);
     }


### PR DESCRIPTION
When we are logging new call from the account page the "Related contact" field is not filled with the default contact. It is more useful when this field is filled with the default contact. Especially when there are lot of accounts and contacts into system.
