### PR TITLE
Add Extended fields synchronisation during lead conversion. Fix #226

### DIFF
--- a/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
+++ b/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
@@ -142,10 +142,7 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
             }
 
             if (in_array($leadFields[$propertyName]['type'], [ 'enum', 'multiEnum' ])) {
-                if ($leadFields[$propertyName]['relation_type'] !== $contactFields[$propertyName]['relation_type']) {
-                    continue;
-                }
-                // @todo check if enum value exists in both types
+                continue;  // Enums are not copied from Lead to Contact
             }
 
             $this->contactFields['properties'][$propertyName] = $propertyName;

--- a/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
+++ b/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
@@ -84,7 +84,6 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
         $this->accessor = PropertyAccess::createPropertyAccessor();
         $this->entityFieldProvider = $entityFieldProvider;
         $this->changeLeadStatus = $changeLeadStatus;
-        $this->validateContactFields();
     }
 
     /**
@@ -165,8 +164,9 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
             {
                 $propertyValue = is_array($value) ? $value['value'] : $this->accessor->getValue($sourceEntity, $value);
 
-                if ($propertyValue)
+                if ($propertyValue) {
                     $this->accessor->setValue($filledEntity, $key, $propertyValue);
+                }
             } catch (AccessException $e) {
 
             }
@@ -181,6 +181,10 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
      */
     protected function prepareContactToOpportunity(Lead $lead)
     {
+        if(empty($this->contactFields['properties'])) {
+            $this->validateContactFields();
+        }
+
         $contact = $lead->getContact();
 
         if (!$contact instanceof Contact) {
@@ -223,10 +227,7 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
     }
 
     /**
-     * @param Lead $lead
-     * @param bool $isGetRequest
-     *
-     * @return Opportunity
+     * {@inheritdoc}
      */
     public function prepareOpportunityForForm(Lead $lead, $isGetRequest = true)
     {
@@ -251,10 +252,7 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
     }
 
     /**
-     * @param Opportunity $opportunity
-     * @param callable    $errorMessageCallback
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function saveOpportunity(Opportunity $opportunity, callable $errorMessageCallback)
     {

--- a/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
+++ b/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
@@ -14,7 +14,7 @@ use Symfony\Component\PropertyAccess\Exception\AccessException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 
-class LeadToOpportunityProvider
+class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
 {
     /** @var PropertyAccessor */
     protected $accessor;
@@ -166,9 +166,7 @@ class LeadToOpportunityProvider
                 $propertyValue = is_array($value) ? $value['value'] : $this->accessor->getValue($sourceEntity, $value);
 
                 if ($propertyValue)
-                {
                     $this->accessor->setValue($filledEntity, $key, $propertyValue);
-                }
             } catch (AccessException $e) {
 
             }

--- a/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
+++ b/src/Oro/Bundle/SalesBundle/Provider/LeadToOpportunityProvider.php
@@ -115,36 +115,37 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
         $leadFields = $this->prepareEntityFields('OroSalesBundle:Lead');
         $contactFields = $this->prepareEntityFields('OroContactBundle:Contact');
 
-        foreach ($contactFields  as $propertyName => $field) {
-
-            if(in_array($propertyName , $this->contactFields['excluded_proprieties']))
+        foreach ($contactFields as $propertyName => $field) {
+            if (in_array($propertyName, $this->contactFields['excluded_proprieties'])) {
                 continue;
+            }
 
-            if (! array_key_exists($propertyName, $leadFields))
+            if (! array_key_exists($propertyName, $leadFields)) {
                 continue;
+            }
 
-            if( $leadFields[$propertyName]['type'] !== $contactFields[$propertyName]['type'])
+            if ($leadFields[$propertyName]['type'] !== $contactFields[$propertyName]['type']) {
                 continue;
+            }
 
-            if(in_array($leadFields[$propertyName]['type'] , [
+            if (in_array($leadFields[$propertyName]['type'], [
                 'ref-one', 'ref-many',
                 'manyToOne', 'oneToMany',
                 'oneToOne', 'ManyToMany',])) {
-
-                if( $leadFields[$propertyName]['relation_type'] !== $contactFields[$propertyName]['relation_type'])
+                if ($leadFields[$propertyName]['relation_type'] !== $contactFields[$propertyName]['relation_type']) {
                     continue;
-
-                if ($leadFields[$propertyName]['related_entity_name'] !== $contactFields[$propertyName]['related_entity_name'])
+                }
+                if ($leadFields[$propertyName]['related_entity_name'] !==
+                    $contactFields[$propertyName]['related_entity_name']) {
                     continue;
+                }
             }
 
-            if(in_array($leadFields[$propertyName]['type'] , [ 'enum', 'multiEnum' ])) {
-
-                if( $leadFields[$propertyName]['relation_type'] !== $contactFields[$propertyName]['relation_type'])
+            if (in_array($leadFields[$propertyName]['type'], [ 'enum', 'multiEnum' ])) {
+                if ($leadFields[$propertyName]['relation_type'] !== $contactFields[$propertyName]['relation_type']) {
                     continue;
-
-                    // @todo check if enum value exists in both types
-
+                }
+                // @todo check if enum value exists in both types
             }
 
             $this->contactFields['properties'][$propertyName] = $propertyName;
@@ -159,18 +160,14 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
     protected function fillEntityProperties($filledEntity, array $properties, $sourceEntity)
     {
         foreach ($properties as $key => $value) {
-
-            try
-            {
+            try {
                 $propertyValue = is_array($value) ? $value['value'] : $this->accessor->getValue($sourceEntity, $value);
 
                 if ($propertyValue) {
                     $this->accessor->setValue($filledEntity, $key, $propertyValue);
                 }
             } catch (AccessException $e) {
-
             }
-
         }
     }
 
@@ -181,7 +178,7 @@ class LeadToOpportunityProvider implements LeadToOpportunityProviderInterface
      */
     protected function prepareContactToOpportunity(Lead $lead)
     {
-        if(empty($this->contactFields['properties'])) {
+        if (empty($this->contactFields['properties'])) {
             $this->validateContactFields();
         }
 

--- a/src/Oro/Bundle/SalesBundle/Tests/Unit/Provider/LeadToOpportunityProviderTest.php
+++ b/src/Oro/Bundle/SalesBundle/Tests/Unit/Provider/LeadToOpportunityProviderTest.php
@@ -21,7 +21,7 @@ class LeadToOpportunityProviderTest extends \PHPUnit_Framework_TestCase
      */
     protected $provider;
 
-    private static  function getLeadFields()
+    private static function getLeadFields()
     {
         return [
             [
@@ -129,19 +129,21 @@ class LeadToOpportunityProviderTest extends \PHPUnit_Framework_TestCase
 
         $entityFieldProvider
             ->method('getFields')
-            ->will( self::returnCallback(function($obj)
-            {
-               if($obj === 'OroContactBundle:Contact')
-                   return LeadToOpportunityProviderTest::getContactFields();
-               if($obj === 'OroSalesBundle:Lead')
-                   return LeadToOpportunityProviderTest::getLeadFields();
-               return null;
+            ->will(self::returnCallback(function ($obj) {
+                if ($obj === 'OroContactBundle:Contact') {
+                    return LeadToOpportunityProviderTest::getContactFields();
+                }
+                if ($obj === 'OroSalesBundle:Lead') {
+                    return LeadToOpportunityProviderTest::getLeadFields();
+                }
+                return null;
             }));
 
         $this->provider = $this->getMockBuilder('Oro\Bundle\SalesBundle\Provider\LeadToOpportunityProvider')
             ->setConstructorArgs([$entityFieldProvider, $changeLeadStatus])
             ->setMethods(['createOpportunity'])
             ->getMock();
+
         $this->provider->expects($this->any())
             ->method('createOpportunity')
             ->will($this->returnCallback(function () {

--- a/src/Oro/Bundle/SalesBundle/Tests/Unit/Provider/LeadToOpportunityProviderTest.php
+++ b/src/Oro/Bundle/SalesBundle/Tests/Unit/Provider/LeadToOpportunityProviderTest.php
@@ -21,6 +21,99 @@ class LeadToOpportunityProviderTest extends \PHPUnit_Framework_TestCase
      */
     protected $provider;
 
+    private static  function getLeadFields()
+    {
+        return [
+            [
+                'name'  => 'firstName',
+                'type'  => 'string',
+                'label' => 'First name',
+            ],
+            [
+                'name'  => 'jobTitle',
+                'type'  => 'string',
+                'label' => 'Job title',
+            ],
+            [
+                'name'  => 'lastName',
+                'type'  => 'string',
+                'label' => 'Last name',
+            ],
+            [
+                'name'  => 'name',
+                'type'  => 'string',
+                'label' => 'Lead name',
+            ],
+            [
+                'name'  => 'middleName',
+                'type'  => 'string',
+                'label' => 'Middle name',
+            ],
+            [
+                'name'  => 'namePrefix',
+                'type'  => 'string',
+                'label' => 'Name prefix',
+            ],
+            [
+                'name'  => 'nameSuffix',
+                'type'  => 'string',
+                'label' => 'Name suffix',
+            ],
+            [
+                'name'                => 'owner',
+                'type'                => 'ref-one',
+                'label'               => 'Owner',
+                'relation_type'       => 'ref-one',
+                'related_entity_name' => 'Oro\\Bundle\\UserBundle\\Entity\\User',
+            ],
+        ];
+    }
+
+    private static function getContactFields()
+    {
+        return [
+            [
+                'name'  => 'firstName',
+                'type'  => 'string',
+                'label' => 'First name',
+            ],
+            [
+                'name'  => 'jobTitle',
+                'type'  => 'string',
+                'label' => 'Job Title',
+            ],
+            [
+                'name'  => 'lastName',
+                'type'  => 'string',
+                'label' => 'Last name',
+            ],
+            [
+                'name'  => 'middleName',
+                'type'  => 'string',
+                'label' => 'Middle name',
+            ],
+            [
+                'name'  => 'namePrefix',
+                'type'  => 'string',
+                'label' => 'Name prefix',
+            ],
+
+            [
+                'name'  => 'nameSuffix',
+                'type'  => 'string',
+                'label' => 'Name suffix',
+            ],
+            [
+                'name'                => 'owner',
+                'type'                => 'ref-one',
+                'label'               => 'Owner',
+                'relation_type'       => 'ref-one',
+                'related_entity_name' => 'Oro\\Bundle\\UserBundle\\Entity\\User',
+            ],
+        ];
+    }
+
+
     public function setUp()
     {
         $entityFieldProvider = $this
@@ -34,7 +127,16 @@ class LeadToOpportunityProviderTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $entityFieldProvider->method('getFields')->willReturn([]);
+        $entityFieldProvider
+            ->method('getFields')
+            ->will( self::returnCallback(function($obj)
+            {
+               if($obj === 'OroContactBundle:Contact')
+                   return LeadToOpportunityProviderTest::getContactFields();
+               if($obj === 'OroSalesBundle:Lead')
+                   return LeadToOpportunityProviderTest::getLeadFields();
+               return null;
+            }));
 
         $this->provider = $this->getMockBuilder('Oro\Bundle\SalesBundle\Provider\LeadToOpportunityProvider')
             ->setConstructorArgs([$entityFieldProvider, $changeLeadStatus])
@@ -73,7 +175,7 @@ class LeadToOpportunityProviderTest extends \PHPUnit_Framework_TestCase
     public function testPrepareOpportunityForFormWithoutContact(Lead $lead, Opportunity $expectedOpportunity)
     {
         $preparedOpportunity = $this->provider->prepareOpportunityForForm($lead, true);
-        $this->assertEquals($preparedOpportunity, $expectedOpportunity);
+        self::assertEquals($expectedOpportunity, $preparedOpportunity);
     }
 
     public function leadProvider()


### PR DESCRIPTION
Hi Oro Team,

This is an attemp in implementing the feature described in #226  Instead of copying only a few specifics fields, between the Lead and Contact, all matching fields will be copied.

Please review before using,I have not touch the Oro internals, it would be fairly possible that some validation are missing ! 

Thanks,
Samuel