### PR TITLE
Define Oro Contact 'firstName' field as filter and sorter in OroCRM JSON API, to be compatible with Brazilian use of names

### DIFF
--- a/src/Oro/Bundle/ContactBundle/Migrations/Schema/v1_17/CreateIndexForFirstName.php
+++ b/src/Oro/Bundle/ContactBundle/Migrations/Schema/v1_17/CreateIndexForFirstName.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Oro\Bundle\ContactBundle\Migrations\Schema\v1_17;
+
+use Doctrine\DBAL\Schema\Schema;
+use Oro\Bundle\MigrationBundle\Migration\Migration;
+use Oro\Bundle\MigrationBundle\Migration\QueryBag;
+
+class CreateIndexForFirstName implements Migration
+{
+    public function up(Schema $schema, QueryBag $queries)
+    {
+        $table = $schema->getTable('orocrm_contact');
+        $table->addIndex(['first_name'], 'orocrm_contact_first_name_idx', []);
+    }
+}

--- a/src/Oro/Bundle/ContactBundle/Resources/config/oro/api.yml
+++ b/src/Oro/Bundle/ContactBundle/Resources/config/oro/api.yml
@@ -26,18 +26,8 @@ api:
                         constraints:
                             - Email: ~
                     property_path: _
-            sorters:
-                fields:
-                    firstName:
-                        exclude: false
-                        property_path: firstName
             filters:
                 fields:
-                    firstName:
-                        exclude: false
-                        data_type: string
-                        property_path: firstName
-                        description: "Filter records by 'firstName' field."
                     phones:
                         data_type: string
                         allow_array: true

--- a/src/Oro/Bundle/ContactBundle/Resources/config/oro/api.yml
+++ b/src/Oro/Bundle/ContactBundle/Resources/config/oro/api.yml
@@ -26,8 +26,18 @@ api:
                         constraints:
                             - Email: ~
                     property_path: _
+            sorters:
+                fields:
+                    firstName:
+                        exclude: false
+                        property_path: firstName
             filters:
                 fields:
+                    firstName:
+                        exclude: false
+                        data_type: string
+                        property_path: firstName
+                        description: "Filter records by 'firstName' field."
                     phones:
                         data_type: string
                         allow_array: true

--- a/src/Oro/Bundle/ContactBundle/Resources/doc/api/contact.md
+++ b/src/Oro/Bundle/ContactBundle/Resources/doc/api/contact.md
@@ -124,6 +124,10 @@ The phone number that should be set as the primary one.
 
 Filter records by email address.
 
+### firstName
+
+Filter records by first name.
+
 ### phones
 
 Filter records by phone number.


### PR DESCRIPTION
Based on #306 .

In Brazil, it's very common to search, filter and sort the contacts by first name. Because of that, Oro should be compatible with this type of use of names. I've created a micro bundle for this (https://github.com/pedrofurtado/orocrm-firstname-api-bundle), but it's much better if this feature is included by default in OroCRM.

Thanks!