### PR TITLE
Website activity events grid on account view is always empty

### DIFF
--- a/src/Oro/Bridge/MarketingCRM/Controller/CustomerController.php
+++ b/src/Oro/Bridge/MarketingCRM/Controller/CustomerController.php
@@ -33,6 +33,10 @@ class CustomerController extends Controller
             FILTER_REQUIRE_ARRAY
         );
 
-        return ['customerIds' => $customerIds];
+        $customerIds = array_filter($customerIds, function ($value) {
+            return $value !== false;
+        });
+
+        return ['customerIds' => count($customerIds) ? $customerIds : false];
     }
 }

--- a/src/Oro/Bridge/MarketingCRM/Controller/CustomerController.php
+++ b/src/Oro/Bridge/MarketingCRM/Controller/CustomerController.php
@@ -29,7 +29,6 @@ class CustomerController extends Controller
         $customerIds = $request->query->filter(
             'customerIds',
             [],
-            false,
             FILTER_VALIDATE_INT,
             FILTER_REQUIRE_ARRAY
         );


### PR DESCRIPTION
Hello,

I've spotted a problem that leads to the inability of viewing the visit events in the Magento Customer view page - to be more exact, the "Events" tab under "Website Activity" always remains empty, thus the logged in user is not able to see the events captured for the viewed Magento customer.

Looking at the way in which the data-source behind this grid is being filtered, I've seen that the request parameter "customerIds" is processed and filtered using an instance of the Symfony HttpFoundation Component ParameterBag class but the way in which the parameters are passed to the "filter" method is  not respecting the method signature - probably due to the jump from Symfony 2.x to 3.x.

I've made a small post processing after filtration so that the value for "customerIds" remains false when there is no valid value in the initial request parameter.