### PR TITLE
Fix Contact Information field in Marketing Lists

### DIFF
--- a/src/Oro/Bundle/AccountBundle/Resources/config/oro/entity.yml
+++ b/src/Oro/Bundle/AccountBundle/Resources/config/oro/entity.yml
@@ -12,8 +12,9 @@ oro_entity:
             contactInformation:
                 query:
                     select:
-                        expr:         defaultContact.email
+                        expr:         emails.email
                         return_type:  string
                     join:
                         left:
                             - { join: entity.defaultContact, alias: defaultContact }
+                            - { join: defaultContact.emails, alias: emails, conditionType: 'WITH', condition: 'emails.primary = true' }


### PR DESCRIPTION
Need this fix https://github.com/oroinc/platform/pull/968 for working

The Account Contact Information virtual field doesn't work in MarketingList

I create new marketing list with `Account` entity and add `Contact Information` field (this field should return the primary email of default contact)

![Capture d’écran - 2019-11-05 à 14 33 04](https://user-images.githubusercontent.com/5607440/68214143-2f6c6900-ffdd-11e9-9b6f-8c292a28ddcb.png)

And `Contact Information` field is empty

![Capture d’écran - 2019-11-05 à 14 33 29](https://user-images.githubusercontent.com/5607440/68214167-3c895800-ffdd-11e9-9084-d6dacf07864a.png)

In `entity.yml` we can see that the fields return the `email` field of `defaultContact`. `Contact::email` is inherited from `BasePerson` and not used.